### PR TITLE
Fix import error for python<3.8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix import error for python<3.8 ([#3](https://github.com/AustinT/mol_ga/pull/3)) ([@austint])
+
 ## [0.1.0] - 2023-09-05
 
 :seedling: Initial public release.

--- a/mol_ga/__init__.py
+++ b/mol_ga/__init__.py
@@ -1,12 +1,15 @@
-from importlib.metadata import PackageNotFoundError, version
-
 from .general_ga import run_ga_maximization
 from .preconfigured_gas import default_ga
 
 __all__ = ["run_ga_maximization", "default_ga"]
 
 try:
-    __version__ = version("mol_ga")
-except PackageNotFoundError:
-    # package is not installed
-    pass
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        __version__ = version("mol_ga")
+    except PackageNotFoundError:
+        # package is not installed
+        pass
+except ModuleNotFoundError:
+    pass  # Python < 3.8


### PR DESCRIPTION
Previously it would fail because importlib.metadata was not added until python 3.8. I put this into a try/except clause so it no longer fails.