### PR TITLE
Santize molecules and prevent crashes from rdkitin GraphGA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Sanitize molecules from GraphGA ([#5](https://github.com/AustinT/mol_ga/pull/5)) ([@austint])
+
 ### Added
 
 ### Fixed
 
 - Fix import error for python<3.8 ([#3](https://github.com/AustinT/mol_ga/pull/3)) ([@austint])
 - Fix unintended use of system random in sampling ([#4](https://github.com/AustinT/mol_ga/pull/4)) ([@austint])
+- Fix occasional crash from rdkit errors during crossover ([#5](https://github.com/AustinT/mol_ga/pull/5)) ([@austint])
 
 ## [0.1.0] - 2023-09-05
 

--- a/mol_ga/graph_ga/gen_candidates.py
+++ b/mol_ga/graph_ga/gen_candidates.py
@@ -12,6 +12,14 @@ from . import mutate as mu
 rd_logger = RDLogger.logger()
 
 
+def sanitize_mol_to_smiles(mol: Chem.Mol) -> Optional[str]:
+    try:
+        Chem.SanitizeMol(mol)
+        return Chem.MolToSmiles(mol, canonical=True, isomericSmiles=True)
+    except Exception:  # unsure what exceptions are thrown
+        return None
+
+
 def reproduce(
     smiles1: str, smiles2: str, mutation_rate: float, rng: Random, crossover_kwargs: Optional[dict] = None
 ) -> Optional[str]:
@@ -31,21 +39,26 @@ def reproduce(
     parent_a = Chem.MolFromSmiles(smiles1)
     parent_b = Chem.MolFromSmiles(smiles2)
     crossover_kwargs = crossover_kwargs or dict()
-    new_child = co.crossover(parent_a, parent_b, rng, **crossover_kwargs)
+    try:
+        new_child = co.crossover(parent_a, parent_b, rng, **crossover_kwargs)
+    except RuntimeError:
+        return None  # occasionally this happens due to internal rdkit errors
     if new_child is not None and rng.random() < mutation_rate:
         new_child = mu.mutate(new_child, rng)
-    if new_child is not None:
-        new_child = Chem.MolToSmiles(new_child, canonical=True)
-    return new_child
+    if new_child is None:
+        return None
+    else:
+        return sanitize_mol_to_smiles(new_child)
 
 
 def mutate(smiles: str, rng: Random) -> Optional[str]:
     """Performs Graph GA mutations on a SMILES string"""
     mol = Chem.MolFromSmiles(smiles)
     new_mol = mu.mutate(mol, rng)
-    if new_mol is not None:
-        new_mol = Chem.MolToSmiles(new_mol, canonical=True, isomericSmiles=True)
-    return new_mol
+    if new_mol is None:
+        return None
+    else:
+        return sanitize_mol_to_smiles(new_mol)
 
 
 def graph_ga_blended_generation(
@@ -65,9 +78,15 @@ def graph_ga_blended_generation(
     rd_logger.setLevel(RDLogger.CRITICAL)
 
     # Step 1: divide samples into "mutate" and "reproduce" sets
-    n_graph_ga_mutate = int(n_candidates * frac_graph_ga_mutate)
-    samples_mutate = samples[:n_graph_ga_mutate]
-    samples_crossover = samples[n_graph_ga_mutate:]
+    samples_mutate: list[str] = []
+    samples_crossover: list[str] = []
+    for s in samples:
+        if rng.random() < frac_graph_ga_mutate:
+            samples_mutate.append(s)
+        else:
+            samples_crossover.append(s)
+    # Ensure there are not too many samples in the mutate set
+    samples_mutate = samples_mutate[: int(n_candidates * frac_graph_ga_mutate + 1)]  # add one to avoid rounding errors
 
     # Step 2: run mutations
     if parallel:


### PR DESCRIPTION
This PR implements two changes related to rdkit.

1. Calls `Chem.SanitizeMol`to prevent any "weird" molecules from being produced.
2. Wraps crossover in try/except to catch occasional errors from rdkit