### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -69,7 +69,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -105,7 +105,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -2,7 +2,11 @@
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 name: Publish mol_ga to PyPI and TestPyPI
 
-on: release
+# Only run this workflow when a release is *published*.
+# Previously this would run on any release event, causing it to run twice by mistake.
+on:
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,7 @@
+# Development
+
+## Releasing a new version on PyPI.
+
+Currently I have a GitHub workflow to automatically publish to PyPI when a new
+[tagged] release is made on GitHub, so the only step required is to make a new
+release.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ This is an open-source project and PRs are welcome!
 
 **!!PLEASE READ THIS SECTION BEFORE MAKING A PR!!**
 
+More information is in `DEVELOPMENT.md`.
+
 ### Pre-commit
 
 Use pre-commit to enforce formatting, large file checks, etc.
@@ -147,10 +149,6 @@ python -m pytest
 ```
 
 Please make sure tests pass on your PR.
-
-### Publishing
-
-Currently the package is set up to publish on PyPI when new tagged releases are created.
 
 ## Misc Information
 


### PR DESCRIPTION
1. Changes from "v3" to "v4" of upload/download artifact actions (to avoid a security vulnerability).
2. Fixed the workflow to run only when a release is *published*, not on the signing part of the release.
3. Change README a bit to reference a new `DEVELOPMENT.md` file.