### PR TITLE
Fix issue caused by RunReactants

### DIFF
--- a/mol_ga/graph_ga/crossover.py
+++ b/mol_ga/graph_ga/crossover.py
@@ -113,10 +113,9 @@ def crossover_ring(parent_A, parent_B, rng: Random, **mol_ok_kwargs):
         new_mol_trial = []  # type: ignore  # wants list type
         for rs in rxn_smarts1:
             rxn1 = AllChem.ReactionFromSmarts(rs)
-            new_mol_trial = []
             for fa in fragments_A:
                 for fb in fragments_B:
-                    new_mol_trial.append(rxn1.RunReactants((fa, fb))[0])
+                    new_mol_trial.extend(rxn1.RunReactants((fa, fb))[0:1])
 
         new_mols = []
         for rs in rxn_smarts2:
@@ -148,7 +147,7 @@ def crossover_non_ring(parent_A, parent_B, rng: Random, **mol_ok_kwargs):
         new_mol_trial = []
         for fa in fragments_A:
             for fb in fragments_B:
-                new_mol_trial.append(rxn.RunReactants((fa, fb))[0])
+                new_mol_trial.extend(rxn.RunReactants((fa, fb))[0:1])
 
         new_mols = []
         for mol in new_mol_trial:


### PR DESCRIPTION
As pointed out in #10, some code in crossover.py can fail if `RunReactants` returns an empty list. This PR fixes this in 2 different places, and also turns off a (probably) erroneous re-initialization of the `new_mol_trial` variable.