### PR TITLE
Remove potentially negative upper bound on molecule size in mol_ok.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Removed size constraint in `crossover.py` which could sometimes be negative ([#16](https://github.com/AustinT/mol_ga/pull/16)) ([@austint]). Thanks [@alstonlo] for pointing this out.
+
 ### Added
 
 ### Fixed
@@ -56,3 +58,4 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 [0.1.0]: https://github.com/AustinT/mol_ga/releases/tag/v0.1.0
 
 [@austint]: https://github.com/AustinT
+[@alstonlo]: https://github.com/alstonlo

--- a/mol_ga/graph_ga/crossover.py
+++ b/mol_ga/graph_ga/crossover.py
@@ -75,16 +75,16 @@ def mol_ok(
     mol,
     rng: Random,
     min_num_atoms=1,
-    mean_num_atoms=40.0,
-    std_num_atoms=1e3,  # by default, no real limit on maximum mol size
 ):
+    """
+    Misc checks to see if a molecule is OK.
+
+    NOTE: edited from the original version of Graph GA to remove the size constraints.
+    If you want size constraints, put it into the objective function.
+    """
     try:
         Chem.SanitizeMol(mol)
-        target_size = rng.gauss(mean_num_atoms, std_num_atoms)
-        if mol.GetNumAtoms() > min_num_atoms and mol.GetNumAtoms() < target_size:
-            return True
-        else:
-            return False
+        return mol.GetNumAtoms() > min_num_atoms
     except ValueError:
         return False
 


### PR DESCRIPTION
I thought the simplest option was to just disable it entirely. This addresses #15.